### PR TITLE
Database connector

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,4 +28,9 @@ jobs:
       run: mvn checkstyle:check
 
     - name: Run tests
+      env:
+        DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+        DB_USERNAME: ${{ secrets.DB_USERNAME }}
+        DB_HOST: ${{ secrets.DB_HOST }}
+        DB_NAME: ${{ secrets.DB_NAME }}
       run: mvn test

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,4 +22,10 @@ jobs:
         cache: maven
       
     - name: Build with Maven
-      run: mvn clean install
+      run: mvn -B clean install -DskipTests
+
+    - name: Run linter
+      run: mvn checkstyle:check
+
+    - name: Run tests
+      run: mvn test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+dependency-reduced-pom.xml
 
 ### IntelliJ IDEA ###
 .idea/

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -7,4 +7,6 @@
 <suppressions>
     <suppress checks="Javadoc" files="."/>
     <suppress checks="TodoComment" files="."/>
+    <suppress checks="DesignForExtension" files="."/>
+    <suppress checks="FinalParameters" files="."/>
 </suppressions>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <property name="severity" value="error"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+
+    <!-- Excludes all 'module-info.java' files              -->
+    <!-- See https://checkstyle.org/filefilters/index.html -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+
+    <!-- https://checkstyle.org/filters/suppressionfilter.html -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
+                  default="checkstyle-suppressions.xml" />
+        <property name="optional" value="true"/>
+    </module>
+
+    <!-- Checks that a package-info.java file exists for each package.     -->
+    <!-- See https://checkstyle.org/checks/javadoc/javadocpackage.html#JavadocPackage -->
+    <module name="JavadocPackage"/>
+
+    <!-- Checks whether files end with a new line.                        -->
+    <!-- See https://checkstyle.org/checks/misc/newlineatendoffile.html -->
+    <module name="NewlineAtEndOfFile"/>
+
+    <!-- Checks that property files contain the same keys.         -->
+    <!-- See https://checkstyle.org/checks/misc/translation.html -->
+    <module name="Translation"/>
+
+    <!-- Checks for Size Violations.                    -->
+    <!-- See https://checkstyle.org/checks/sizes/index.html -->
+    <module name="FileLength"/>
+    <module name="LineLength">
+        <property name="fileExtensions" value="java"/>
+    </module>
+
+    <!-- Checks for whitespace                               -->
+    <!-- See https://checkstyle.org/checks/whitespace/index.html -->
+    <module name="FileTabCharacter"/>
+
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See https://checkstyle.org/checks/misc/index.html -->
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$"/>
+        <property name="minimum" value="0"/>
+        <property name="maximum" value="0"/>
+        <property name="message" value="Line has trailing spaces."/>
+    </module>
+
+    <!-- Checks for Headers                                -->
+    <!-- See https://checkstyle.org/checks/header/index.html   -->
+    <!-- <module name="Header"> -->
+    <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
+    <!--   <property name="fileExtensions" value="java"/> -->
+    <!-- </module> -->
+
+    <module name="TreeWalker">
+
+        <!-- Checks for Javadoc comments.                     -->
+        <!-- See https://checkstyle.org/checks/javadoc/index.html -->
+        <module name="InvalidJavadocPosition"/>
+        <module name="JavadocMethod"/>
+        <module name="JavadocType"/>
+        <module name="JavadocVariable"/>
+        <module name="JavadocStyle"/>
+        <module name="MissingJavadocMethod"/>
+
+        <!-- Checks for Naming Conventions.                  -->
+        <!-- See https://checkstyle.org/checks/naming/index.html -->
+        <module name="ConstantName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MemberName"/>
+        <module name="MethodName"/>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+
+        <!-- Checks for imports                              -->
+        <!-- See https://checkstyle.org/checks/imports/index.html -->
+        <module name="AvoidStarImport"/>
+        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+        <module name="RedundantImport"/>
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="false"/>
+        </module>
+
+        <!-- Checks for Size Violations.                    -->
+        <!-- See https://checkstyle.org/checks/sizes/index.html -->
+        <module name="MethodLength"/>
+        <module name="ParameterNumber"/>
+
+        <!-- Checks for whitespace                               -->
+        <!-- See https://checkstyle.org/checks/whitespace/index.html -->
+        <module name="EmptyForIteratorPad"/>
+        <module name="GenericWhitespace"/>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceAfter"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="OperatorWrap"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+
+        <!-- Modifier Checks                                    -->
+        <!-- See https://checkstyle.org/checks/modifier/index.html -->
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+
+        <!-- Checks for blocks. You know, those {}'s         -->
+        <!-- See https://checkstyle.org/checks/blocks/index.html -->
+        <module name="AvoidNestedBlocks"/>
+        <module name="EmptyBlock"/>
+        <module name="LeftCurly"/>
+        <module name="NeedBraces"/>
+        <module name="RightCurly"/>
+
+        <!-- Checks for common coding problems               -->
+        <!-- See https://checkstyle.org/checks/coding/index.html -->
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment"/>
+        <module name="MagicNumber"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- Checks for class design                         -->
+        <!-- See https://checkstyle.org/checks/design/index.html -->
+        <module name="DesignForExtension"/>
+        <module name="FinalClass"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="InterfaceIsType"/>
+        <module name="VisibilityModifier"/>
+
+        <!-- Miscellaneous other checks.                   -->
+        <!-- See https://checkstyle.org/checks/misc/index.html -->
+        <module name="ArrayTypeStyle"/>
+        <module name="FinalParameters"/>
+        <module name="TodoComment"/>
+        <module name="UpperEll"/>
+
+        <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
+        <module name="SuppressionXpathFilter">
+            <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
+                      default="checkstyle-xpath-suppressions.xml" />
+            <property name="optional" value="true"/>
+        </module>
+
+    </module>
+
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.3.1</version>
                 <configuration>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <suppressionsLocation>
                         checkstyle-suppressions.xml
                     </suppressionsLocation>

--- a/pom.xml
+++ b/pom.xml
@@ -142,15 +142,6 @@
                         checkstyle-suppressions.xml
                     </suppressionsLocation>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,16 @@
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.28</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -139,9 +149,8 @@
                 <version>3.3.1</version>
                 <configuration>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                    <suppressionsLocation>
-                        checkstyle-suppressions.xml
-                    </suppressionsLocation>
+                    <configLocation>checkstyle.xml</configLocation>
+                    <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/org/kainos/ea/DropwizardWebServiceApplication.java
+++ b/src/main/java/org/kainos/ea/DropwizardWebServiceApplication.java
@@ -12,7 +12,7 @@ public class DropwizardWebServiceApplication
     }
 
     @Override
-    public final String getName() {
+    public String getName() {
         return "DropwizardWebService";
     }
 

--- a/src/main/java/org/kainos/ea/db/DatabaseConnector.java
+++ b/src/main/java/org/kainos/ea/db/DatabaseConnector.java
@@ -1,0 +1,65 @@
+package org.kainos.ea.db;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public final class DatabaseConnector {
+    public static final String ENV_DB_USERNAME = "DB_USERNAME";
+    public static final String ENV_DB_PASSWORD = "DB_PASSWORD";
+    public static final String ENV_DB_HOST = "DB_HOST";
+    public static final String ENV_DB_NAME = "DB_NAME";
+
+    private static Connection connection;
+
+    public static void resetConnection() {
+        DatabaseConnector.connection = null;
+    }
+
+    private DatabaseConnector() {
+
+    }
+
+    public static DatabaseProperties getDatabaseProperties() {
+        String user = System.getenv(ENV_DB_USERNAME);
+        String password = System.getenv(ENV_DB_PASSWORD);
+        String host = System.getenv(ENV_DB_HOST);
+        String name = System.getenv(ENV_DB_NAME);
+
+        return new DatabaseProperties(user, password, host, name);
+    }
+
+    public static Connection getConnection(DatabaseProperties props)
+            throws SQLException {
+        return DriverManager.getConnection(
+                "jdbc:mysql://" + props.getHost() + "/" + props.getName()
+                        + "?useSSL=false",
+                props.getUsername(), props.getPassword());
+    }
+
+    public static Connection getConnection()
+            throws SQLException {
+        if (DatabaseConnector.connection != null
+                && !DatabaseConnector.connection.isClosed()) {
+            return DatabaseConnector.connection;
+        }
+
+        try {
+            DatabaseProperties props = getDatabaseProperties();
+
+            if (!props.isValid()) {
+                throw new IllegalArgumentException(
+                        "Environment variables must be set for "
+                        + "DB_USERNAME, DB_PASSWORD, DB_HOST, and DB_NAME."
+                );
+            }
+
+            DatabaseConnector.connection = getConnection(props);
+            return DatabaseConnector.connection;
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/kainos/ea/db/DatabaseProperties.java
+++ b/src/main/java/org/kainos/ea/db/DatabaseProperties.java
@@ -1,0 +1,59 @@
+package org.kainos.ea.db;
+
+public class DatabaseProperties {
+    private String username;
+    private String password;
+    private String host;
+    private String name;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String user) {
+        this.username = user;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public DatabaseProperties(
+            String username,
+            String password,
+            String host,
+            String name
+    ) {
+        this.username = username;
+        this.password = password;
+        this.host = host;
+        this.name = name;
+    }
+
+    public boolean isValid() {
+        return this.username != null
+                && this.password != null
+                && this.host != null
+                && this.name != null;
+    }
+}

--- a/src/test/java/org/kainos/ea/db/DatabaseConnectorTest.java
+++ b/src/test/java/org/kainos/ea/db/DatabaseConnectorTest.java
@@ -1,0 +1,32 @@
+package org.kainos.ea.db;
+
+import com.mysql.cj.jdbc.exceptions.CommunicationsException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DatabaseConnectorTest {
+    @Test
+    @DisplayName("Test valid SQL connection")
+    void testSQLConnectionValid() throws SQLException {
+        Connection connection = DatabaseConnector.getConnection();
+        assertNotNull(connection);
+        assertFalse(connection.isClosed());
+    }
+
+    @Test
+    @DisplayName("Test invalid SQL connection")
+    void testSQLConnectionInvalid() {
+        DatabaseProperties props = new DatabaseProperties(
+                "user", "password", "host", "name");
+        assertThrows(CommunicationsException.class, () -> {
+            DatabaseConnector.getConnection(props);
+        });
+    }
+}

--- a/src/test/java/org/kainos/ea/db/DatabasePropertiesTest.java
+++ b/src/test/java/org/kainos/ea/db/DatabasePropertiesTest.java
@@ -1,0 +1,69 @@
+package org.kainos.ea.db;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DatabasePropertiesTest {
+    @Test
+    @DisplayName("Test for DatabaseProperties constructor and getters")
+    void testDatabasePropertiesConstructorAndGetters() {
+        String expectedUsername = "TestUser";
+        String expectedPassword = "TestPassword";
+        String expectedHost = "TestHost";
+        String expectedName = "TestName";
+        DatabaseProperties props = new DatabaseProperties(
+                expectedUsername,
+                expectedPassword,
+                expectedHost,
+                expectedName
+        );
+        assertEquals(expectedUsername, props.getUsername());
+        assertEquals(expectedPassword, props.getPassword());
+        assertEquals(expectedHost, props.getHost());
+        assertEquals(expectedName, props.getName());
+    }
+
+    @Test
+    @DisplayName("Test for isValid() with valid input")
+    void testIsValidNotNull() {
+        DatabaseProperties props = new DatabaseProperties(
+                "user", "password", "host", "name");
+        assertTrue(props.isValid());
+    }
+
+    @Test
+    @DisplayName("Test for isValid() with the user null")
+    void testIsValidUserNull() {
+        DatabaseProperties props = new DatabaseProperties(
+                null, "password", "host", "name");
+        assertFalse(props.isValid());
+    }
+
+    @Test
+    @DisplayName("Test for isValid() with the password null")
+    void testIsValidPasswordNull() {
+        DatabaseProperties props = new DatabaseProperties(
+                "user", null, "host", "name");
+        assertFalse(props.isValid());
+    }
+
+    @Test
+    @DisplayName("Test for isValid() with the host null")
+    void testIsValidHostNull() {
+        DatabaseProperties props = new DatabaseProperties(
+                "user", "password", null, "name");
+        assertFalse(props.isValid());
+    }
+
+    @Test
+    @DisplayName("Test for isValid() with the name null")
+    void testIsValidNameNull() {
+        DatabaseProperties props = new DatabaseProperties(
+                "user", "password", "host", null);
+        assertFalse(props.isValid());
+    }
+}


### PR DESCRIPTION
Implements the following:
1. Runs linter and tests independent of mvn clean install
- This change is neccessary for the Database connector PR as this PR is the first one to add proper functionality (requires unit tests which should be run automatically through GitHub Actions)
- Originally "Build maven" would run the checkstyle checks as well which is a bit misleading
- Now they are separate, `mvn test` is now also being run after the checkstyle checks (Note: no tests have actually been implemented yet)
- Old: ![Screenshot 2023-12-06 at 09 49 42](https://github.com/BlankAmber/Kainos-RRAS-API/assets/145449058/de3674eb-6aa6-4218-a016-68a054b37d6e)
- New: 
![Screenshot 2023-12-06 at 09 51 41](https://github.com/BlankAmber/Kainos-RRAS-API/assets/145449058/4703ec55-0406-461e-94c1-5aa4b18fc4b9)
2. Adjusts linter config
3. Adds the database connector + appropriate unit tests

To use this locally remember to set environment variables for DB_USERNAME, DB_PASSWORD, DB_HOST, and DB_NAME.

E.g.
`export VAR_NAME="value here"`

Also set the environment variables for the run configuration in IntelliJ too.