### PR TITLE
US040 - Login System

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,35 +2,43 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ main, ready-for-signoff ]
+    branches:
+      - main
   pull_request:
-    branches: [ main, ready-for-signoff ]
+
+env:
+  DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+  DB_USERNAME: ${{ secrets.DB_USERNAME }}
+  DB_HOST: ${{ secrets.DB_HOST }}
+  DB_NAME: ${{ secrets.DB_NAME }}
+  TEST_ADMIN_ACCOUNT_USERNAME: ${{ secrets.TEST_ADMIN_ACCOUNT_USERNAME }}
+  TEST_ADMIN_ACCOUNT_PASSWORD: ${{ secrets.TEST_ADMIN_ACCOUNT_PASSWORD }}
+  TEST_EMPLOYEE_ACCOUNT_USERNAME: ${{ secrets.TEST_EMPLOYEE_ACCOUNT_USERNAME }}
+  TEST_EMPLOYEE_ACCOUNT_PASSWORD: ${{ secrets.TEST_EMPLOYEE_ACCOUNT_PASSWORD }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-      
+
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
         java-version: '11'
         distribution: 'temurin'
         cache: maven
-      
+
     - name: Build with Maven
       run: mvn -B clean install -DskipTests
 
+    - name: Run unit tests
+      run: mvn clean test
+
+    - name: Run integration tests
+      run: mvn clean verify -DskipUnitTests
+
     - name: Run linter
       run: mvn checkstyle:check
-
-    - name: Run tests
-      env:
-        DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-        DB_USERNAME: ${{ secrets.DB_USERNAME }}
-        DB_HOST: ${{ secrets.DB_HOST }}
-        DB_NAME: ${{ secrets.DB_NAME }}
-      run: mvn test

--- a/README.md
+++ b/README.md
@@ -1,13 +1,37 @@
 # Kainos-RRAS-API
 
-How to start the DropwizardWebService application
+Config
 ---
+1. The following environment variables need to be set to enable database connection:
+```
+DB_USERNAME
+DB_PASSWORD
+DB_HOST
+DB_NAME
+```
+2. If running integration tests, then the following environment variables need to be set:
+```
+TEST_ADMIN_ACCOUNT_USERNAME
+TEST_ADMIN_ACCOUNT_PASSWORD
+TEST_ADMIN_ACCOUNT_USERNAME
+TEST_ADMIN_ACCOUNT_USERNAME
+```
 
-1. Run `mvn clean install` to build your application
-1. Start application with `java -jar target/DropwizardWebService-1.0-SNAPSHOT.jar server config.yml`
-1. To check that your application is running enter url `http://localhost:8080`
-
-Health Check
+How to start the application
 ---
+1. Run `mvn clean install -DskipTests` to build your application
+2. Start application with `java -jar target/DropwizardWebService-1.0-SNAPSHOT.jar server config.yml`
+3. To check that your application is running enter url `http://localhost:8080`
 
-To see your applications health enter url `http://localhost:8081/healthcheck`
+Swagger
+---
+To see your applications Swagger UI `http://localhost:8080/swagger`
+
+Tests
+---
+1. Run `mvn clean test` to run unit tests
+2. Run `mvn clean verify -DskipUnitTests` to run integration tests
+
+Linter
+---
+1. Run `mvn checkstyle:check`

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -9,4 +9,5 @@
     <suppress checks="TodoComment" files="."/>
     <suppress checks="DesignForExtension" files="."/>
     <suppress checks="FinalParameters" files="."/>
+    <suppress checks="MethodName" files="^.*?/test/.*\.java$"/>
 </suppressions>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -38,6 +38,7 @@
     <module name="FileLength"/>
     <module name="LineLength">
         <property name="fileExtensions" value="java"/>
+        <property name="max" value="100"/>
     </module>
 
     <!-- Checks for whitespace                               -->

--- a/config.yml
+++ b/config.yml
@@ -2,3 +2,6 @@ logging:
   level: INFO
   loggers:
     org.kainos.ea: DEBUG
+
+swagger:
+  resourcePackage: com.kainos.ea

--- a/database/DatabaseScript.sql
+++ b/database/DatabaseScript.sql
@@ -3,3 +3,25 @@ CREATE DATABASE IF NOT EXISTS KainosJobs_AdamM;
 
 -- Use the database
 USE KainosJobs_AdamM;
+
+DROP TABLE IF EXISTS role;
+DROP TABLE IF EXISTS user;
+DROP TABLE IF EXISTS token;
+
+CREATE TABLE role (
+    role_id int PRIMARY KEY AUTO_INCREMENT,
+    role_name varchar(30) NOT NULL
+);
+
+CREATE TABLE user (
+    username varchar(30) PRIMARY KEY COLLATE utf8mb4_bin,
+    role_id varchar(30) NOT NULL REFERENCES role (role_id),
+    salt char(8) NOT NULL,
+    secured_password varchar(100) NOT NULL
+);
+
+CREATE TABLE token (
+    username varchar(30) REFERENCES user (username),
+    token varchar(64) NOT NULL,
+    expiry_date DATETIME NOT NULL
+);

--- a/database/InsertingData.sql
+++ b/database/InsertingData.sql
@@ -1,0 +1,7 @@
+INSERT INTO role (role_name) VALUES
+    ('admin'),
+    ('employee');
+
+INSERT INTO user (username, role_id, salt, secured_password) VALUES
+    ('Admin123', 1, 'qwertyui', '062742bd7303fd97dc3e059dc3595e97114ae28815901c518b9a4e283e9512f6'),
+    ('Employee123', 2, 'asdfghjk', '79fb350ff31e939d2b5d4b8ed498e2ec6782eed7943e943d29e40c6e4fbd077d');

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,17 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.smoketurner</groupId>
+            <artifactId>dropwizard-swagger</artifactId>
+            <version>2.0.0-1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>2.0.23</dropwizard.version>
         <mainClass>org.kainos.ea.DropwizardWebServiceApplication</mainClass>
+        <skipTests>false</skipTests>
+        <skipUnitTests>${skipTests}</skipUnitTests>
     </properties>
 
     <dependencyManagement>
@@ -67,6 +69,28 @@
                 <exclusion>
                     <groupId>javax.validation</groupId>
                     <artifactId>validation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>2.23.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.9.10</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -129,6 +153,24 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <skipTests>${skipUnitTests}</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <executions>
+                    <execution>
+                        <id>run-integration-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>

--- a/src/main/java/org/kainos/ea/DropwizardWebServiceApplication.java
+++ b/src/main/java/org/kainos/ea/DropwizardWebServiceApplication.java
@@ -3,6 +3,9 @@ package org.kainos.ea;
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import io.federecio.dropwizard.swagger.SwaggerBundle;
+import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
+import org.kainos.ea.resources.AuthController;
 
 public class DropwizardWebServiceApplication
         extends Application<DropwizardWebServiceConfiguration> {
@@ -19,13 +22,18 @@ public class DropwizardWebServiceApplication
     @Override
     public void initialize(
             final Bootstrap<DropwizardWebServiceConfiguration> bootstrap) {
-        // TODO: application initialization
+        bootstrap.addBundle(new SwaggerBundle<DropwizardWebServiceConfiguration>() {
+            @Override
+            protected SwaggerBundleConfiguration getSwaggerBundleConfiguration(
+                    DropwizardWebServiceConfiguration configuration) {
+                return configuration.getSwagger();
+            }
+        });
     }
 
     @Override
     public void run(final DropwizardWebServiceConfiguration configuration,
                     final Environment environment) {
-        // TODO: implement application
+        environment.jersey().register(new AuthController());
     }
-
 }

--- a/src/main/java/org/kainos/ea/DropwizardWebServiceConfiguration.java
+++ b/src/main/java/org/kainos/ea/DropwizardWebServiceConfiguration.java
@@ -1,7 +1,22 @@
 package org.kainos.ea;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 public class DropwizardWebServiceConfiguration extends Configuration {
-    // TODO: implement service configuration
+    @Valid
+    @NotNull
+    private final SwaggerBundleConfiguration swagger = new SwaggerBundleConfiguration();
+
+    @JsonProperty("swagger")
+    public SwaggerBundleConfiguration getSwagger() {
+        swagger.setResourcePackage("org.kainos.ea.resources");
+        String[] schemes = {"http", "https"};
+        swagger.setSchemes(schemes);
+        return swagger;
+    }
 }

--- a/src/main/java/org/kainos/ea/Util.java
+++ b/src/main/java/org/kainos/ea/Util.java
@@ -1,0 +1,17 @@
+package org.kainos.ea;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public final class Util {
+    private Util() {
+
+    }
+
+    public static void setValues(PreparedStatement preparedStatement, Object... values)
+            throws SQLException {
+        for (int i = 0; i < values.length; i++) {
+            preparedStatement.setObject(i + 1, values[i]);
+        }
+    }
+}

--- a/src/main/java/org/kainos/ea/api/AuthService.java
+++ b/src/main/java/org/kainos/ea/api/AuthService.java
@@ -3,21 +3,37 @@ package org.kainos.ea.api;
 import org.kainos.ea.cli.Login;
 import org.kainos.ea.client.FailedToGenerateTokenException;
 import org.kainos.ea.client.FailedToLoginException;
+import org.kainos.ea.client.FailedToValidateLoginException;
 import org.kainos.ea.db.AuthDao;
+import org.kainos.ea.db.DatabaseConnector;
 
 import java.sql.SQLException;
 
 public class AuthService {
-    private final AuthDao authDao = new AuthDao();
+    private final AuthDao authDao;
+    private final DatabaseConnector databaseConnector;
 
-    public String login(Login login) throws FailedToLoginException, FailedToGenerateTokenException {
-        if (authDao.isValidLogin(login)) {
-            try {
-                return authDao.generateToken(login.getUsername());
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new FailedToGenerateTokenException();
+    public AuthService(AuthDao authDao, DatabaseConnector databaseConnector) {
+        this.authDao = authDao;
+        this.databaseConnector = databaseConnector;
+    }
+
+    public String login(Login login)
+            throws FailedToGenerateTokenException,
+            FailedToValidateLoginException, FailedToLoginException {
+        try {
+            if (authDao.isValidLogin(login, databaseConnector.getConnection())) {
+                try {
+                    return authDao.generateToken(login.getUsername(),
+                            databaseConnector.getConnection());
+                } catch (SQLException e) {
+                    System.err.println(e.getMessage());
+                    throw new FailedToGenerateTokenException();
+                }
             }
+        } catch (SQLException e) {
+            System.err.println(e.getMessage());
+            throw new FailedToValidateLoginException();
         }
 
         throw new FailedToLoginException();

--- a/src/main/java/org/kainos/ea/api/AuthService.java
+++ b/src/main/java/org/kainos/ea/api/AuthService.java
@@ -1,0 +1,25 @@
+package org.kainos.ea.api;
+
+import org.kainos.ea.cli.Login;
+import org.kainos.ea.client.FailedToGenerateTokenException;
+import org.kainos.ea.client.FailedToLoginException;
+import org.kainos.ea.db.AuthDao;
+
+import java.sql.SQLException;
+
+public class AuthService {
+    private final AuthDao authDao = new AuthDao();
+
+    public String login(Login login) throws FailedToLoginException, FailedToGenerateTokenException {
+        if (authDao.isValidLogin(login)) {
+            try {
+                return authDao.generateToken(login.getUsername());
+            } catch (SQLException e) {
+                System.err.println(e.getMessage());
+                throw new FailedToGenerateTokenException();
+            }
+        }
+
+        throw new FailedToLoginException();
+    }
+}

--- a/src/main/java/org/kainos/ea/cli/Login.java
+++ b/src/main/java/org/kainos/ea/cli/Login.java
@@ -1,0 +1,33 @@
+package org.kainos.ea.cli;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Login {
+    private String username;
+    private String password;
+
+    @JsonCreator
+    public Login(
+            @JsonProperty("username") String username,
+            @JsonProperty("password") String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/org/kainos/ea/client/FailedToGenerateTokenException.java
+++ b/src/main/java/org/kainos/ea/client/FailedToGenerateTokenException.java
@@ -1,0 +1,7 @@
+package org.kainos.ea.client;
+
+public class FailedToGenerateTokenException extends Exception {
+    public String getMessage() {
+        return "Failed to generate token";
+    }
+}

--- a/src/main/java/org/kainos/ea/client/FailedToLoginException.java
+++ b/src/main/java/org/kainos/ea/client/FailedToLoginException.java
@@ -1,0 +1,7 @@
+package org.kainos.ea.client;
+
+public class FailedToLoginException extends Exception {
+    public String getMessage() {
+        return "Failed to login";
+    }
+}

--- a/src/main/java/org/kainos/ea/client/FailedToValidateLoginException.java
+++ b/src/main/java/org/kainos/ea/client/FailedToValidateLoginException.java
@@ -1,0 +1,7 @@
+package org.kainos.ea.client;
+
+public class FailedToValidateLoginException extends Exception {
+    public String getMessage() {
+        return "Failed to validate login";
+    }
+}

--- a/src/main/java/org/kainos/ea/client/FailedToVerifyTokenException.java
+++ b/src/main/java/org/kainos/ea/client/FailedToVerifyTokenException.java
@@ -1,0 +1,8 @@
+package org.kainos.ea.client;
+
+public class FailedToVerifyTokenException extends Exception {
+    @Override
+    public String getMessage() {
+        return "Failed to verify token";
+    }
+}

--- a/src/main/java/org/kainos/ea/db/AuthDao.java
+++ b/src/main/java/org/kainos/ea/db/AuthDao.java
@@ -1,0 +1,68 @@
+package org.kainos.ea.db;
+
+import org.apache.commons.lang3.time.DateUtils;
+import org.kainos.ea.Util;
+import org.kainos.ea.cli.Login;
+
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.ResultSet;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.UUID;
+
+public class AuthDao {
+    private static final int TOKEN_EXPIRY_NUM_HOURS_AFTER_LOGIN = 8;
+
+    public boolean isValidLogin(Login login) {
+        try (Connection conn = DatabaseConnector.getConnection()) {
+            Statement statement = conn.createStatement();
+
+            ResultSet resultSet = statement.executeQuery(
+                    "SELECT salt, secured_password FROM user WHERE username = "
+                    + "'" + login.getUsername() + "'");
+
+            if (resultSet.next()) {
+                String salt = resultSet.getString("salt");
+                String saltedPassword = login.getPassword() + salt;
+
+                MessageDigest messageDigest = null;
+                try {
+                    messageDigest = MessageDigest.getInstance("SHA-256");
+                } catch (NoSuchAlgorithmException e) {
+                    System.err.println("Algorithm not found!");
+                }
+
+                byte[] encodedHash = messageDigest.digest(saltedPassword.getBytes());
+                String securedPassword = String.format("%064x", new BigInteger(1, encodedHash));
+
+                return resultSet.getString("secured_password").equals(securedPassword);
+            }
+        } catch (SQLException e) {
+            System.err.println(e.getMessage());
+        }
+
+        return false;
+    }
+
+    public String generateToken(String username) throws SQLException {
+        String token = UUID.randomUUID().toString();
+        // TODO: Test this with different timezones
+        Date expiryDate = DateUtils.addHours(new Date(), TOKEN_EXPIRY_NUM_HOURS_AFTER_LOGIN);
+
+        Connection c = DatabaseConnector.getConnection();
+
+        String insertStatement = "INSERT INTO token (username, token, expiry_date) VALUES (?,?,?)";
+
+        PreparedStatement statement = c.prepareStatement(insertStatement);
+        Util.setValues(statement, username, token, new Timestamp(expiryDate.getTime()));
+        statement.executeUpdate();
+
+        return token;
+    }
+}

--- a/src/main/java/org/kainos/ea/db/AuthDao.java
+++ b/src/main/java/org/kainos/ea/db/AuthDao.java
@@ -19,47 +19,41 @@ import java.util.UUID;
 public class AuthDao {
     private static final int TOKEN_EXPIRY_NUM_HOURS_AFTER_LOGIN = 8;
 
-    public boolean isValidLogin(Login login) {
-        try (Connection conn = DatabaseConnector.getConnection()) {
-            Statement statement = conn.createStatement();
+    public boolean isValidLogin(Login login, Connection conn) throws SQLException {
+        Statement statement = conn.createStatement();
 
-            ResultSet resultSet = statement.executeQuery(
-                    "SELECT salt, secured_password FROM user WHERE username = "
-                    + "'" + login.getUsername() + "'");
+        ResultSet resultSet = statement.executeQuery(
+                "SELECT salt, secured_password FROM user WHERE username = "
+                + "'" + login.getUsername() + "'");
 
-            if (resultSet.next()) {
-                String salt = resultSet.getString("salt");
-                String saltedPassword = login.getPassword() + salt;
+        if (resultSet.next()) {
+            String salt = resultSet.getString("salt");
+            String saltedPassword = login.getPassword() + salt;
 
-                MessageDigest messageDigest = null;
-                try {
-                    messageDigest = MessageDigest.getInstance("SHA-256");
-                } catch (NoSuchAlgorithmException e) {
-                    System.err.println("Algorithm not found!");
-                }
-
-                byte[] encodedHash = messageDigest.digest(saltedPassword.getBytes());
-                String securedPassword = String.format("%064x", new BigInteger(1, encodedHash));
-
-                return resultSet.getString("secured_password").equals(securedPassword);
+            MessageDigest messageDigest = null;
+            try {
+                messageDigest = MessageDigest.getInstance("SHA-256");
+            } catch (NoSuchAlgorithmException e) {
+                System.err.println("Algorithm not found!");
             }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
+
+            byte[] encodedHash = messageDigest.digest(saltedPassword.getBytes());
+            String securedPassword = String.format("%064x", new BigInteger(1, encodedHash));
+
+            return resultSet.getString("secured_password").equals(securedPassword);
         }
 
         return false;
     }
 
-    public String generateToken(String username) throws SQLException {
+    public String generateToken(String username, Connection conn) throws SQLException {
         String token = UUID.randomUUID().toString();
         // TODO: Test this with different timezones
         Date expiryDate = DateUtils.addHours(new Date(), TOKEN_EXPIRY_NUM_HOURS_AFTER_LOGIN);
 
-        Connection c = DatabaseConnector.getConnection();
-
         String insertStatement = "INSERT INTO token (username, token, expiry_date) VALUES (?,?,?)";
 
-        PreparedStatement statement = c.prepareStatement(insertStatement);
+        PreparedStatement statement = conn.prepareStatement(insertStatement);
         Util.setValues(statement, username, token, new Timestamp(expiryDate.getTime()));
         statement.executeUpdate();
 

--- a/src/main/java/org/kainos/ea/db/AuthDao.java
+++ b/src/main/java/org/kainos/ea/db/AuthDao.java
@@ -1,7 +1,6 @@
 package org.kainos.ea.db;
 
 import org.apache.commons.lang3.time.DateUtils;
-import org.kainos.ea.Util;
 import org.kainos.ea.cli.Login;
 
 import java.math.BigInteger;
@@ -54,7 +53,11 @@ public class AuthDao {
         String insertStatement = "INSERT INTO token (username, token, expiry_date) VALUES (?,?,?)";
 
         PreparedStatement statement = conn.prepareStatement(insertStatement);
-        Util.setValues(statement, username, token, new Timestamp(expiryDate.getTime()));
+        DaoUtil.populatePreparedStatement(statement,
+                username,
+                token,
+                new Timestamp(expiryDate.getTime())
+        );
         statement.executeUpdate();
 
         return token;

--- a/src/main/java/org/kainos/ea/db/DaoUtil.java
+++ b/src/main/java/org/kainos/ea/db/DaoUtil.java
@@ -1,14 +1,15 @@
-package org.kainos.ea;
+package org.kainos.ea.db;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-public final class Util {
-    private Util() {
+public final class DaoUtil {
+    private DaoUtil() {
 
     }
 
-    public static void setValues(PreparedStatement preparedStatement, Object... values)
+    public static void populatePreparedStatement(
+            PreparedStatement preparedStatement, Object... values)
             throws SQLException {
         for (int i = 0; i < values.length; i++) {
             preparedStatement.setObject(i + 1, values[i]);

--- a/src/main/java/org/kainos/ea/db/DatabaseConnector.java
+++ b/src/main/java/org/kainos/ea/db/DatabaseConnector.java
@@ -4,7 +4,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
-public final class DatabaseConnector {
+public class DatabaseConnector {
     public static final String ENV_DB_USERNAME = "DB_USERNAME";
     public static final String ENV_DB_PASSWORD = "DB_PASSWORD";
     public static final String ENV_DB_HOST = "DB_HOST";
@@ -12,24 +12,16 @@ public final class DatabaseConnector {
 
     private static Connection connection;
 
-    public static void resetConnection() {
-        DatabaseConnector.connection = null;
-    }
-
-    private DatabaseConnector() {
-
-    }
-
-    public static DatabaseProperties getDatabaseProperties() {
-        String user = System.getenv(ENV_DB_USERNAME);
+    public DatabaseProperties getDatabaseProperties() {
+        String username = System.getenv(ENV_DB_USERNAME);
         String password = System.getenv(ENV_DB_PASSWORD);
         String host = System.getenv(ENV_DB_HOST);
         String name = System.getenv(ENV_DB_NAME);
 
-        return new DatabaseProperties(user, password, host, name);
+        return new DatabaseProperties(username, password, host, name);
     }
 
-    public static Connection getConnection(DatabaseProperties props)
+    public Connection getConnection(DatabaseProperties props)
             throws SQLException {
         return DriverManager.getConnection(
                 "jdbc:mysql://" + props.getHost() + "/" + props.getName()
@@ -37,7 +29,7 @@ public final class DatabaseConnector {
                 props.getUsername(), props.getPassword());
     }
 
-    public static Connection getConnection()
+    public Connection getConnection()
             throws SQLException {
         if (DatabaseConnector.connection != null
                 && !DatabaseConnector.connection.isClosed()) {

--- a/src/main/java/org/kainos/ea/resources/AuthController.java
+++ b/src/main/java/org/kainos/ea/resources/AuthController.java
@@ -5,6 +5,9 @@ import org.kainos.ea.api.AuthService;
 import org.kainos.ea.cli.Login;
 import org.kainos.ea.client.FailedToGenerateTokenException;
 import org.kainos.ea.client.FailedToLoginException;
+import org.kainos.ea.client.FailedToValidateLoginException;
+import org.kainos.ea.db.AuthDao;
+import org.kainos.ea.db.DatabaseConnector;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -15,7 +18,7 @@ import javax.ws.rs.core.Response;
 @Api("RRAS Auth API")
 @Path("/api")
 public class AuthController {
-    private final AuthService authService = new AuthService();
+    private final AuthService authService = new AuthService(new AuthDao(), new DatabaseConnector());
 
     @POST
     @Path("/login")
@@ -28,7 +31,7 @@ public class AuthController {
 
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity(e.getMessage()).build();
-        } catch (FailedToGenerateTokenException e) {
+        } catch (FailedToGenerateTokenException | FailedToValidateLoginException e) {
             System.err.println(e.getMessage());
 
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/src/main/java/org/kainos/ea/resources/AuthController.java
+++ b/src/main/java/org/kainos/ea/resources/AuthController.java
@@ -1,0 +1,38 @@
+package org.kainos.ea.resources;
+
+import io.swagger.annotations.Api;
+import org.kainos.ea.api.AuthService;
+import org.kainos.ea.cli.Login;
+import org.kainos.ea.client.FailedToGenerateTokenException;
+import org.kainos.ea.client.FailedToLoginException;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Api("RRAS Auth API")
+@Path("/api")
+public class AuthController {
+    private final AuthService authService = new AuthService();
+
+    @POST
+    @Path("/login")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response login(Login login) {
+        try {
+            return Response.ok(authService.login(login)).build();
+        } catch (FailedToLoginException e) {
+            System.err.println(e.getMessage());
+
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(e.getMessage()).build();
+        } catch (FailedToGenerateTokenException e) {
+            System.err.println(e.getMessage());
+
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(e.getMessage()).build();
+        }
+    }
+}

--- a/src/test/java/org/kainos/ea/db/DatabaseConnectorTest.java
+++ b/src/test/java/org/kainos/ea/db/DatabaseConnectorTest.java
@@ -14,19 +14,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class DatabaseConnectorTest {
     @Test
     @DisplayName("Test valid SQL connection")
-    void testSQLConnectionValid() throws SQLException {
-        Connection connection = DatabaseConnector.getConnection();
+    void getConnection_withNoInput_shouldReturnValidConnection() throws SQLException {
+        DatabaseConnector databaseConnector = new DatabaseConnector();
+        Connection connection = databaseConnector.getConnection();
         assertNotNull(connection);
         assertFalse(connection.isClosed());
     }
 
     @Test
     @DisplayName("Test invalid SQL connection")
-    void testSQLConnectionInvalid() {
+    void getConnection_withInvalidDatabaseProperties_shouldThrowCommunicationsException() {
+        DatabaseConnector databaseConnector = new DatabaseConnector();
         DatabaseProperties props = new DatabaseProperties(
                 "user", "password", "host", "name");
         assertThrows(CommunicationsException.class, () -> {
-            DatabaseConnector.getConnection(props);
+            databaseConnector.getConnection(props);
         });
     }
 }

--- a/src/test/java/org/kainos/ea/db/DatabasePropertiesTest.java
+++ b/src/test/java/org/kainos/ea/db/DatabasePropertiesTest.java
@@ -9,8 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DatabasePropertiesTest {
     @Test
-    @DisplayName("Test for DatabaseProperties constructor and getters")
-    void testDatabasePropertiesConstructorAndGetters() {
+    @DisplayName("Test for constructor and getters")
+    void constructorAndGetters() {
         String expectedUsername = "TestUser";
         String expectedPassword = "TestPassword";
         String expectedHost = "TestHost";
@@ -29,7 +29,7 @@ public class DatabasePropertiesTest {
 
     @Test
     @DisplayName("Test for isValid() with valid input")
-    void testIsValidNotNull() {
+    void isValid_withValidProperties_shouldReturnTrue() {
         DatabaseProperties props = new DatabaseProperties(
                 "user", "password", "host", "name");
         assertTrue(props.isValid());
@@ -37,7 +37,7 @@ public class DatabasePropertiesTest {
 
     @Test
     @DisplayName("Test for isValid() with the user null")
-    void testIsValidUserNull() {
+    void isValid_withNullUsername_shouldReturnFalse() {
         DatabaseProperties props = new DatabaseProperties(
                 null, "password", "host", "name");
         assertFalse(props.isValid());
@@ -45,7 +45,7 @@ public class DatabasePropertiesTest {
 
     @Test
     @DisplayName("Test for isValid() with the password null")
-    void testIsValidPasswordNull() {
+    void isValid_withNullPassword_shouldReturnFalse() {
         DatabaseProperties props = new DatabaseProperties(
                 "user", null, "host", "name");
         assertFalse(props.isValid());
@@ -53,7 +53,7 @@ public class DatabasePropertiesTest {
 
     @Test
     @DisplayName("Test for isValid() with the host null")
-    void testIsValidHostNull() {
+    void isValid_withNullHost_shouldReturnFalse() {
         DatabaseProperties props = new DatabaseProperties(
                 "user", "password", null, "name");
         assertFalse(props.isValid());
@@ -61,7 +61,7 @@ public class DatabasePropertiesTest {
 
     @Test
     @DisplayName("Test for isValid() with the name null")
-    void testIsValidNameNull() {
+    void isValid_withNullName_shouldReturnFalse() {
         DatabaseProperties props = new DatabaseProperties(
                 "user", "password", "host", null);
         assertFalse(props.isValid());

--- a/src/test/java/org/kainos/ea/integration/AuthIT.java
+++ b/src/test/java/org/kainos/ea/integration/AuthIT.java
@@ -1,0 +1,99 @@
+package org.kainos.ea.integration;
+
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kainos.ea.DropwizardWebServiceApplication;
+import org.kainos.ea.DropwizardWebServiceConfiguration;
+import org.kainos.ea.cli.Login;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class AuthIT {
+    static final DropwizardAppExtension<DropwizardWebServiceConfiguration> APP =
+            new DropwizardAppExtension<>(
+                    DropwizardWebServiceApplication.class, null,
+                    new ResourceConfigurationSourceProvider()
+    );
+
+    @Test
+    @DisplayName("Test valid login to an admin account")
+    void postLogin_withValidAdminAccount_shouldReturnToken() {
+        Login login = new Login(
+                System.getenv("TEST_ADMIN_ACCOUNT_USERNAME"),
+                System.getenv("TEST_ADMIN_ACCOUNT_PASSWORD")
+        );
+
+        String token = APP.client().target("http://localhost:8080/api/login")
+                .request()
+                .post(Entity.entity(login, MediaType.APPLICATION_JSON_TYPE))
+                .readEntity(String.class);
+        assertNotNull(token);
+    }
+
+    @Test
+    @DisplayName("Test valid login to an employee account")
+    void postLogin_withValidEmployeeAccount_shouldReturnToken() {
+        Login login = new Login(
+                System.getenv("TEST_EMPLOYEE_ACCOUNT_USERNAME"),
+                System.getenv("TEST_EMPLOYEE_ACCOUNT_PASSWORD")
+        );
+
+        String token = APP.client().target("http://localhost:8080/api/login")
+                .request()
+                .post(Entity.entity(login, MediaType.APPLICATION_JSON_TYPE))
+                .readEntity(String.class);
+        assertNotNull(token);
+    }
+
+    @Test
+    @DisplayName("Test login invalid password to an admin account")
+    void postLogin_withInvalidPasswordForAdminAccount_shouldReturnBadRequestError() {
+        Login login = new Login(
+                System.getenv("TEST_ADMIN_ACCOUNT_USERNAME"),
+                "TestPassword"
+        );
+
+        Response response = APP.client().target("http://localhost:8080/api/login")
+                .request()
+                .post(Entity.entity(login, MediaType.APPLICATION_JSON_TYPE));
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    @DisplayName("Test login invalid password to an employee account")
+    void postLogin_withInvalidPasswordForEmployeeAccount_shouldReturnBadRequestError() {
+        Login login = new Login(
+                System.getenv("TEST_EMPLOYEE_ACCOUNT_USERNAME"),
+                "TestPassword"
+        );
+
+        Response response = APP.client().target("http://localhost:8080/api/login")
+                .request()
+                .post(Entity.entity(login, MediaType.APPLICATION_JSON_TYPE));
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    @DisplayName("Test login invalid account info")
+    void postLogin_withInvalidAccountInfo_shouldReturnErrorBadRequestError() {
+        Login login = new Login(
+                "NotARealUser",
+                "NotARealPassword"
+        );
+
+        Response response = APP.client().target("http://localhost:8080/api/login")
+                .request()
+                .post(Entity.entity(login, MediaType.APPLICATION_JSON_TYPE));
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+}

--- a/src/test/java/org/kainos/ea/service/AuthServiceTest.java
+++ b/src/test/java/org/kainos/ea/service/AuthServiceTest.java
@@ -1,0 +1,76 @@
+package org.kainos.ea.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kainos.ea.api.AuthService;
+import org.kainos.ea.cli.Login;
+import org.kainos.ea.client.FailedToGenerateTokenException;
+import org.kainos.ea.client.FailedToLoginException;
+import org.kainos.ea.client.FailedToValidateLoginException;
+import org.kainos.ea.db.AuthDao;
+import org.kainos.ea.db.DatabaseConnector;
+import org.mockito.Mockito;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AuthServiceTest {
+    private final AuthDao authDao = Mockito.mock(AuthDao.class);;
+    private final DatabaseConnector databaseConnector = Mockito.mock(DatabaseConnector.class);
+    private final Connection conn = Mockito.mock(Connection.class);
+
+    private final AuthService authService = new AuthService(authDao, databaseConnector);
+
+    private final Login login = new Login("AdminTest", "Password%");
+
+    @Test
+    @DisplayName("Test valid login")
+    void login_whenDaoIsValidLoginReturnsTrue_shouldReturnToken()
+            throws SQLException,
+            FailedToGenerateTokenException,
+            FailedToValidateLoginException, FailedToLoginException {
+        String expectedToken = "token";
+
+        Mockito.when(databaseConnector.getConnection()).thenReturn(conn);
+        Mockito.when(authDao.isValidLogin(login, conn)).thenReturn(true);
+        Mockito.when(authDao.generateToken(login.getUsername(), conn)).thenReturn(expectedToken);
+
+        assertEquals(expectedToken, authService.login(login));
+    }
+
+    @Test
+    @DisplayName("Test invalid login")
+    void login_whenDaoIsValidLoginReturnsFalse_shouldThrowFailedToLoginException()
+            throws SQLException {
+        Mockito.when(databaseConnector.getConnection()).thenReturn(conn);
+        Mockito.when(authDao.isValidLogin(login, conn)).thenReturn(false);
+
+        assertThrows(FailedToLoginException.class,
+                () -> authService.login(login));
+    }
+
+    @Test
+    @DisplayName("Test login FailedToGenerateToken exception")
+    void login_whenDaoGenerateTokenThrowsSQLException_shouldThrowFailedToGenerateTokenException()
+            throws SQLException {
+        Mockito.when(databaseConnector.getConnection()).thenReturn(conn);
+        Mockito.when(authDao.isValidLogin(login, conn)).thenReturn(true);
+        Mockito.when(authDao.generateToken(login.getUsername(), conn))
+                .thenThrow(SQLException.class);
+
+        assertThrows(FailedToGenerateTokenException.class, () -> authService.login(login));
+    }
+
+    @Test
+    @DisplayName("Test login FailedToValidateLogin exception")
+    void login_whenDaoIsValidLoginThrowsSQLException_shouldThrowFailedToValidateLoginException()
+            throws SQLException {
+        Mockito.when(databaseConnector.getConnection()).thenReturn(conn);
+        Mockito.when(authDao.isValidLogin(login, conn)).thenThrow(SQLException.class);
+
+        assertThrows(FailedToValidateLoginException.class, () -> authService.login(login));
+    }
+}


### PR DESCRIPTION
This PR implements the backend for the [`US040 - Login System`](https://tasks.office.com/kainos.com/Home/Task/b_OhVXRyQEGETWG0--tRX5YAKUk2?Type=TaskLink&Channel=Link&CreatedTime=638380949683020000) ticket.

As swagger is implemented, this PR also completes the [`US027 - Swagger Documentation for API Routes`](https://tasks.office.com/kainos.com/Home/Task/m4J0L_Ry9EG8fTUy59IsqJYALN7P?Type=TaskLink&Channel=Link&CreatedTime=638380957825400000) ticket. Swagger API documentation should be implemented in all future PRs that add new backend APIs.

This PR also implements the [`US032 - Update README for running and testing`](https://tasks.office.com/kainos.com/Home/Task/nz476nf8u0GbzPoz79akB5YAE5W4?Type=TaskLink&Channel=Link&CreatedTime=638381432930090000) ticket.

Note that the `AuthDao.generateToken(String username, Connection conn)` method has not been tested for correct functionality across timezones as this is above my paygrade.

For future tickets, ensure integration tests end with `IT.java` so the automatic categorisation of unit tests vs integration tests is accurate.

The backend can be run using:
`java -jar target/DropwizardWebService-1.0-SNAPSHOT.jar server config.yml`

The following environment variables must be set:
- DB_HOST
- DB_NAME
- DB_PASSWORD
- DB_USERNAME
- TEST_ADMIN_ACCOUNT_USERNAME
- TEST_ADMIN_ACCOUNT_PASSWORD
- TEST_EMPLOYEE_ACCOUNT_USERNAME
- TEST_EMPLOYEE_ACCOUNT_PASSWORD

Changes:
- Checkstyle max length adjusted from 80 to 100
- Implement swagger
- SQL tables necessary for the login system added
- Data necessary for the login system inserted into SQL tables (all passwords are salted and hashed using SHA-256)
    - Salts inserted were arbitrarily chosen. Real salts used will most likely be more complicated and the algorithm for generating them should be implemented in the [`US024 - Registration System`](https://tasks.office.com/kainos.com/Home/Task/-LpElUzK40epI97zNycNUZYABeGF?Type=TaskLink&Channel=Link&CreatedTime=638380975895090000) ticket
- Implement API endpoint POST /login
    - Adds `Util` class with `setValues(PreparedStatement preparedStatement, Object... values)` method to prevent the use of magic numbers in Dao methods
    - Endpoint returns a token based on a randomly generated UUID
    - Salting and hashing of passwords is implemented by appending the salt to the password and hashing said salted password using SHA-256
- Implement login system unit and integration tests
    - Rework `maven.yml` for clarity, introduction of test environment variables, and to separate the unit and integration tests. The linter also now runs after the tests
    - Suppress checkstyle MethodName check for all test classes
    - Correct issues with `config.yml` required to run backend via CLI
    - Add `mockito-junit-jupiter`, `net.bytebuddy`, `dropwizard-testing`, and `maven-failsafe-plugin` dependencies
    - Make DatabaseConnector a non-static class so it can be mocked
    - Rename DatabaseConnector and DatabaseProperties test methods for consistency
- Change `DatabaseProperties.user` to `DatabaseProperties.username` for clarity

Screenshots:
<img width="403" alt="Screenshot 2023-12-13 at 20 57 17" src="https://github.com/BlankAmber/Kainos-RRAS-API/assets/145449058/3f3658e0-38c6-4286-95b5-27ad1c662d62">
<img width="406" alt="Screenshot 2023-12-13 at 20 58 29" src="https://github.com/BlankAmber/Kainos-RRAS-API/assets/145449058/67af091d-7732-463c-83ee-46783fc8ae61">
<img width="287" alt="Screenshot 2023-12-13 at 20 58 42" src="https://github.com/BlankAmber/Kainos-RRAS-API/assets/145449058/b7877bf6-608d-4f71-a1a7-7aa2033511d7">
<img width="968" alt="Screenshot 2023-12-13 at 20 59 23" src="https://github.com/BlankAmber/Kainos-RRAS-API/assets/145449058/df9b3ea7-f807-47af-acd1-17690fd59202">
